### PR TITLE
Backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+dist/
 junk/
 *.pyc
 .vscode

--- a/README.md
+++ b/README.md
@@ -24,20 +24,18 @@ Here we use PySoundFile to read a .wav file as an ndarray.
 import soundfile as sf
 import pyloudnorm as pyln
 
-data, rate = sf.read("test.wav") # load audio
+data, rate = sf.read("test.wav") # load audio (with shape (samples, channels))
 meter = pyln.Meter(rate) # create BS.1770 meter
 loudness = meter.integrated_loudness(data) # measure loudness
 ```
 
 ### Loudness normalize and peak normalize audio files
 Methods are included to normalize audio files to desired peak values or desired loudness.
-Again we use scipy to read a wav file as an ndarray.
 ```python
 import soundfile as sf
 import pyloudnorm as pyln
 
-# load audio
-data, rate = sf.read("test.wav")
+data, rate = sf.read("test.wav") # load audio
 
 # peak normalize audio to -1 dB
 peak_normalized_audio = pyln.normalize.peak(data, -1.0)
@@ -54,7 +52,6 @@ loudness_normalized_audio = pyln.normalize.loudness(data, loudness, -12.0)
 - **SciPy** ([https://www.scipy.org/](https://www.scipy.org/))
 - **NumPy** ([http://www.numpy.org/](http://www.numpy.org/))
 - **Matplotlib** ([https://matplotlib.org/](https://matplotlib.org/))
-- **PySoundFile** ([https://github.com/bastibe/SoundFile](https://github.com/bastibe/SoundFile))
 
 ## Todo
 - Add true peak measurement 

--- a/pyloudnorm/meter.py
+++ b/pyloudnorm/meter.py
@@ -56,6 +56,10 @@ class Meter():
         the integrated loudness is measured based upon the gating algorithm
         defined in the ITU-R BS.1770-4 specification. 
 
+        Input data must have shape (samples, ch) or (samples,) for mono audio.
+        Supports up to 5 channels and follows the channel ordering: 
+        [Left, Right, Center, Left surround, Right surround]
+
         Params
         -------
         data : ndarray
@@ -122,7 +126,7 @@ class Meter():
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             # calculate the average of z[i,j] as show in eq. 7 with blocks above both thresholds
-            z_avg_gated = np.nan_to_num([np.mean([z[i,j] for j in J_g]) for i in range(numChannels)])
+            z_avg_gated = np.nan_to_num(np.array([np.mean([z[i,j] for j in J_g])) for i in range(numChannels)])
         
         # calculate final loudness gated loudness (see eq. 7)
         with np.errstate(divide='ignore'):

--- a/pyloudnorm/meter.py
+++ b/pyloudnorm/meter.py
@@ -126,7 +126,7 @@ class Meter():
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             # calculate the average of z[i,j] as show in eq. 7 with blocks above both thresholds
-            z_avg_gated = np.nan_to_num(np.array([np.mean([z[i,j] for j in J_g])) for i in range(numChannels)])
+            z_avg_gated = np.nan_to_num(np.array([np.mean([z[i,j] for j in J_g]) for i in range(numChannels)]))
         
         # calculate final loudness gated loudness (see eq. 7)
         with np.errstate(divide='ignore'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy==1.0.1
-numpy==1.14.2
-matplotlib==2.1.1
-pysoundfile==0.9.0
+scipy>=1.0.1
+numpy>=1.14.2
+matplotlib>=2.1.1
+pysoundfile>=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,24 @@
-from distutils.core import setup
+from setuptools import setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
 setup(name='pyloudnorm',
-      version='0.5',
-      description='Implementation of ITU-R BS.1770-4 loudness algorithm in python',
+      version='0.0.1',
+      description='Implementation of ITU-R BS.1770-4 loudness algorithm in Python',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
+      url='https://github.com/csteinmetz1/pyloudnorm',
       author='Christian Steinmetz',
       author_email='cjstein@clemson.edu',
       packages=['pyloudnorm'],
-     )
+      install_requires=['scipy>=1.0.1',
+                        'numpy>=1.14.2',
+                        'matplotlib>=2.1.1'],
+      classifiers=(
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 2.7",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+      ),
+)


### PR DESCRIPTION
Add support for older versions of numpy (<=1.8) where array_like function parameters must instead be ndarray. Additional update of README and doc strings for usage clarity.