### PR TITLE
[ADD] basic implementation of LRA based on EBU tech3342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy>=1.0.1
 numpy>=1.14.2
 matplotlib>=2.1.1
-pysoundfile>=0.9.0
+soundfile>=0.12.1


### PR DESCRIPTION
This PR includes the followings: 

- a basic implementation for calculating LRA based on the Matlab example in the EBU tech 3342 report. 
- The implementation was tested locally (Python 3.10) on the 6 test signals specified in the report (available here: https://tech.ebu.ch/publications/ebu_loudness_test_set), and the values are within +- 1LU. 
- The implementation was tested locally on 7 long-form content (i.e., 1~2 hours long) and compared against another implementation (DPLM). The values are within +- 1LU. 

There are minor changes to the main functions in order to enable this calculation, but they should not interfere the main functionalities. Please have a look and test it in your dev environment. Happy to debug (as I am sure there will be plenty 😂 )
